### PR TITLE
Fix classification name.

### DIFF
--- a/overlord.yml
+++ b/overlord.yml
@@ -1,4 +1,4 @@
-classification: tier1
+classification: tier_1
 owner: @girasquid
 team: 
 deploy_url: https://example.com/deploy


### PR DESCRIPTION
As was discussed on https://github.com/clio/overlord/pull/4#discussion_r203915388 , tier names are going to be snake_case.

Until this PR is merged, I'm leaving a small hack (with a note to remove it) in Overlord that normalizes to the snake_case variants.